### PR TITLE
v2.2.1

### DIFF
--- a/deep-iterable.js
+++ b/deep-iterable.js
@@ -76,13 +76,14 @@
 		}
 
 		[Symbol.iterator]() {
+			var self = this;
 			var parents = [];
-			var circular = this.circular;
-			return iterate(this.base, this.deeper, this.equal);
+			var circular = self.circular;
+			return iterate(self.base, self.deeper, self.equal);
 			function * iterate(base, deeper, equal) {
-				if (isIterable(base) && deeper(base, this)) {
+				if (isIterable(base) && deeper(base, self)) {
 					if (parents.find((element) => equal(base, element))) {
-						yield * circular(base, this) || EMPTY_GENERATOR;
+						yield * circular(base, self) || EMPTY_GENERATOR;
 					} else {
 						parents.push(base);
 						for (let element of base) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "x-iterable",
 	"description": "Extensible Iterable class creation utilities",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"author": "Hoàng Văn Khải <hvksmr1996@gmail.com>",
 	"contributors": [
 		"Hoàng Văn Khải <hvksmr1996@gmail.com>"


### PR DESCRIPTION
Fixed bug:
 - In `DeepIterable` &rightarrow; `Circular` &rightarrow; `[Symbol.iterator]` &rightarrow; `iterate`: `circular` and `deeper` no longer receive `undefined` as the second arguments, instead, a `CircularDeepIterable`